### PR TITLE
Serialize dictionaries and maps

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -185,3 +185,17 @@ def test_constant():
         assert {
             'type': 'constant', 'value': value
         } == convert(vol.Schema(value))
+
+def test_dictionary_schema():
+    assert [{
+        'type': 'dictionary',
+        'dictionary': [{'type': 'string', 'name': 'def'}],
+        'name': 'abc'
+    }] == convert(vol.Schema({"abc": {"def": str}}))
+
+def test_mapping_schema():
+    assert {
+        'type': 'mapping',
+        'key': {'type': 'integer'},
+        'value': {'type': 'string'}
+    } == convert(vol.Schema({int: str}))

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -38,7 +38,9 @@ def convert(schema, *, custom_serializer=None):
 
             if not isinstance(pkey, str):
                 if len(schema) != 1:
-                    raise ValueError('Unable to convert schema: {}'.format(schema))
+                    raise ValueError(
+                        'Unable to convert schema: {}'.format(schema)
+                    )
                 return {
                     'type': 'mapping',
                     'key': convert(key),

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -39,7 +39,11 @@ def convert(schema, *, custom_serializer=None):
             if not isinstance(pkey, str):
                 if len(schema) != 1:
                     raise ValueError('Unable to convert schema: {}'.format(schema))
-                return {'type': 'mapping', 'key': convert(key), 'value': convert(value)}
+                return {
+                    'type': 'mapping',
+                    'key': convert(key),
+                    'value': convert(value)
+                }
 
             pval = convert(value, custom_serializer=custom_serializer)
             if isinstance(pval, list):

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -36,7 +36,14 @@ def convert(schema, *, custom_serializer=None):
             else:
                 pkey = key
 
+            if not isinstance(pkey, str):
+                if len(schema) != 1:
+                    raise ValueError('Unable to convert schema: {}'.format(schema))
+                return {'type': 'mapping', 'key': convert(key), 'value': convert(value)}
+
             pval = convert(value, custom_serializer=custom_serializer)
+            if isinstance(pval, list):
+                pval = {'type': 'dictionary', 'dictionary': pval}
             pval['name'] = pkey
             if description is not None:
                 pval['description'] = description


### PR DESCRIPTION
I want to enable the home assistant backend to support more complex schemas. The first step is to be able to serialize them to the front end. the suggested change has two variants, both shown in the tests:
1. sub-dictionary: Schema("a": { "b" : str}} - this will create a serialized item with type="dictionary" and a key "dictionary" for the serialized internal schema
2. mapping: this is for maps where the keys are not set, such as Schema({int: str}). this will be serialized as type="mapping", "key"=schema for the key and "value" for the schema for the value