### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           pip install -r requirements_test.txt

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(
     license="Apache License 2.0",
     install_requires=["voluptuous"],
     packages=["voluptuous_serialize"],
+    python_requires=">=3.9",
     zip_safe=True,
 )


### PR DESCRIPTION
- Python 3.8 was end of life in October 2024.