### PR TITLE
Improve error handling for unsupported object

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
+import pytest
 import voluptuous as vol
-
 from voluptuous_serialize import UNSUPPORTED, convert
 
 
@@ -214,3 +214,16 @@ def test_enum():
             (2, 2),
         ],
     } == convert(vol.Schema(vol.Coerce(TestEnum)))
+
+
+def test_raise_unsupported_instance():
+    with pytest.raises(ValueError, match=r"^Unable to convert schema:"):
+        convert(vol.Schema(vol.IsFalse()))
+
+
+def test_raise_unsupported_class():
+    class UnsupportedClass:
+        pass
+
+    with pytest.raises(ValueError, match=r"^Unable to convert schema:"):
+        convert(vol.Schema(UnsupportedClass))

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -5,7 +5,6 @@ from enum import Enum
 
 import voluptuous as vol
 
-
 TYPES_MAP = {
     int: "integer",
     str: "string",
@@ -118,7 +117,7 @@ def convert(schema, *, custom_serializer=None):
     if isinstance(schema, (str, int, float, bool)):
         return {"type": "constant", "value": schema}
 
-    if issubclass(schema, Enum):
+    if isinstance(schema, type) and issubclass(schema, Enum):
         return {
             "type": "select",
             "options": [(item.value, item.value) for item in schema],


### PR DESCRIPTION
Previously, when trying to validate an unsupported object it would raise 
`TypeError: issubclass() arg 1 must be a class`
from `if issubclass(schema, Enum):`
without further info what part of the schema did raise that.

Now it would fall through to `raise ValueError("Unable to convert schema: {}".format(schema))` which should yield a better error message.