### PR TITLE
Improve README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Voluptuous Serialize
 
-Convert Voluptuous schemas to dictionaries so they can be serialized.
+Convert Voluptuous schemas to json serializable objects.
 
 ```python
-from collections import OrderedDict
+import voluptuous as vol
+from voluptuous_serialize import convert
 
-# Use OrderedDict instead of dict.
-# Only starting Python 3.6+ are dictionaries ordered.
-schema = OrderedDict()
-schema[vol.Required('name')] = vol.All(str, vol.Length(min=5))
-schema[vol.Required('age')] = vol.All(vol.Coerce(int), vol.Range(min=18))
-schema[vol.Optional('hobby', default='not specified')] = str
-schema = vol.Schema(schema)
+schema = vol.Schema(
+    {
+        vol.Required("name"): vol.All(str, vol.Length(min=5)),
+        vol.Required("age"): vol.All(vol.Coerce(int), vol.Range(min=18)),
+        vol.Optional("hobby", default="not specified"): str,
+    }
+)
+result = convert(schema)
 ```
 
 becomes


### PR DESCRIPTION
- Since `convert` returns either a dict or a list, it shouldn't state that the results are dictionaries.
- Use `dict` instead of `OrderedDict` to create schema in example. This is the most common way to use it and dicts are ordered anyway with the minimum required python version for this package.