### PR TITLE
Check for nested mapping schemas raise properly

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -277,11 +277,18 @@ def test_unsupported_schema(unsupported_schema):
         vol.All(
             vol.Schema({vol.Required("a"): int}),
         ),
+        {
+            "name": str,
+            "position": {
+                "lat": float,
+                "lon": float,
+            },
+        },
     ],
 )
 def test_unsupported_subschema(unsupported_schema):
     with pytest.raises(
         ValueError,
-        match=r"^Unable to convert `.*` subschema:",
+        match=r"^Unable to convert .*schema:",
     ):
         convert(vol.Schema(unsupported_schema))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -268,3 +268,31 @@ def test_unsupported_schema(unsupported_schema):
         match=re.escape(f"Unable to convert schema: {unsupported_schema}"),
     ):
         convert(vol.Schema(unsupported_schema))
+
+
+@pytest.mark.parametrize(
+    "unsupported_schema",
+    [
+        vol.All({"a": int}),
+        vol.All(
+            vol.Schema(
+                {
+                    vol.Required("a"): int,
+                    vol.Required("x"): int,
+                    vol.Required("y"): int,
+                },
+            ),
+            vol.Schema(
+                {
+                    vol.Required("a"): int,
+                }
+            ),
+        ),
+    ],
+)
+def test_unsupported_subschema(unsupported_schema):
+    with pytest.raises(
+        ValueError,
+        match=r"^Unable to convert `.*` subschema:",
+    ):
+        convert(vol.Schema(unsupported_schema))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -275,18 +275,7 @@ def test_unsupported_schema(unsupported_schema):
     [
         vol.All({"a": int}),
         vol.All(
-            vol.Schema(
-                {
-                    vol.Required("a"): int,
-                    vol.Required("x"): int,
-                    vol.Required("y"): int,
-                },
-            ),
-            vol.Schema(
-                {
-                    vol.Required("a"): int,
-                }
-            ),
+            vol.Schema({vol.Required("a"): int}),
         ),
     ],
 )

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -38,6 +38,9 @@ def convert(schema, *, custom_serializer=None):
                 pkey = key
 
             pval = convert(value, custom_serializer=custom_serializer)
+            if isinstance(pval, list):
+                # nested Mapping schemas are not supported
+                raise ValueError(f"Unable to convert nested mapping schema: {value}")
             pval["name"] = pkey
             if description is not None:
                 pval["description"] = description

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -55,7 +55,13 @@ def convert(schema, *, custom_serializer=None):
     if isinstance(schema, vol.All):
         val = {}
         for validator in schema.validators:
-            val.update(convert(validator, custom_serializer=custom_serializer))
+            pval = convert(validator, custom_serializer=custom_serializer)
+            if isinstance(pval, list):
+                # Mapping schemas in vol.All are not supported
+                raise ValueError(
+                    f"Unable to convert `voluptuous.All` subschema: {validator}"
+                )
+            val.update(pval)
         return val
 
     if isinstance(schema, (vol.Clamp, vol.Range)):
@@ -123,4 +129,4 @@ def convert(schema, *, custom_serializer=None):
             "options": [(item.value, item.value) for item in schema],
         }
 
-    raise ValueError("Unable to convert schema: {}".format(schema))
+    raise ValueError(f"Unable to convert schema: {schema}")


### PR DESCRIPTION
Fix handling of nested dictionary schemas.

```py
convert(vol.Schema(vol.All({"a": int})))`
# would result in 
{'type': 'name'}
```
which is unintentional. 
This is since `dict.update` can work with an iterable of key-value pairs
```py
convert({"a":int})
# returns such an iterable
[{'type': 'integer', 'name': 'a'}]`
```
but `{'type': 'integer', 'name': 'a'}` isn't a valid key-value pair for our needs. It would iterate over it, yielding only the keys ("type" and "name").

For sub-schemas like
```py
vol.All(
    vol.Schema({vol.Required("a"): int}),
),
# where the handler would break down the schema into
convert(vol.Schema({vol.Required("a"): int}))
# that would result in
[{'type': 'integer', 'name': 'a', 'required': True}]
# which is passed to `dict.update`
```
and raise `ValueError: dictionary update sequence element #0 has length 3; 2 is required`.

Nested schemas without `vol.All` would have raised
```py
convert(
    vol.Schema(
        {
            "name": str,
            "position": {"lat": float, "lon": float},
        }
    )
)
TypeError: list indices must be integers or slices, not str
```

All of these cases now raise proper error messages.