### PR TITLE
Consistently mark required fields of mapping schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _(dictionaries become lists to guarantee order of properties)_
     "type": "string",
     "default": "not specified",
     "required": false,
-    "optional": true,  // This will be deprecated soon. Please use "required" key instead.
+    "optional": true,  // This is deprecated. Please use "required" key instead.
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _(dictionaries become lists to guarantee order of properties)_
     "type": "string",
     "default": "not specified",
     "required": false,
-    "optional": true,
+    "optional": true,  // This will be deprecated soon. Please use "required" key instead.
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ _(dictionaries become lists to guarantee order of properties)_
     "name": "hobby",
     "type": "string",
     "default": "not specified",
-    "optional": true,
+    "required": false,
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ _(dictionaries become lists to guarantee order of properties)_
     "type": "string",
     "default": "not specified",
     "required": false,
+    "optional": true,
   }
 ]
 ```

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 import pytest
 import voluptuous as vol
-
 from voluptuous_serialize import UNSUPPORTED, convert
 
 
@@ -94,6 +93,7 @@ def test_dict(base_required):
             "type": "string",
             "default": "not specified",
             "required": False,
+            "optional": True,
         },
     ] == convert(
         vol.Schema(

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -74,7 +74,8 @@ def test_in_dict():
     )
 
 
-def test_dict():
+@pytest.mark.parametrize("base_required", [True, False])
+def test_dict(base_required):
     assert [
         {
             "name": "name",
@@ -86,21 +87,22 @@ def test_dict():
             "name": "age",
             "type": "integer",
             "valueMin": 18,
-            "required": True,
+            "required": base_required,
         },
         {
             "name": "hobby",
             "type": "string",
             "default": "not specified",
-            "optional": True,
+            "required": False,
         },
     ] == convert(
         vol.Schema(
             {
                 vol.Required("name"): vol.All(str, vol.Length(min=5)),
-                vol.Required("age"): vol.All(vol.Coerce(int), vol.Range(min=18)),
+                "age": vol.All(vol.Coerce(int), vol.Range(min=18)),
                 vol.Optional("hobby", default="not specified"): str,
-            }
+            },
+            required=base_required,
         )
     )
 

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -18,7 +18,10 @@ UNSUPPORTED = object()
 def convert(schema, *, custom_serializer=None):
     """Convert a voluptuous schema to a dictionary."""
     # pylint: disable=too-many-return-statements,too-many-branches
+    base_required = False  # vol.Schema default
+
     if isinstance(schema, vol.Schema):
+        base_required = schema.required
         schema = schema.schema
 
     if custom_serializer:
@@ -46,10 +49,12 @@ def convert(schema, *, custom_serializer=None):
                 pval["description"] = description
 
             if isinstance(key, (vol.Required, vol.Optional)):
-                pval[key.__class__.__name__.lower()] = True
+                pval["required"] = isinstance(key, vol.Required)
 
                 if key.default is not vol.UNDEFINED:
                     pval["default"] = key.default()
+            else:
+                pval["required"] = base_required
 
             val.append(pval)
 

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -51,6 +51,9 @@ def convert(schema, *, custom_serializer=None):
             if isinstance(key, (vol.Required, vol.Optional)):
                 pval["required"] = isinstance(key, vol.Required)
 
+                # for backward compatibility
+                pval[key.__class__.__name__.lower()] = True
+
                 if key.default is not vol.UNDEFINED:
                     pval["default"] = key.default()
             else:


### PR DESCRIPTION
Mark requirement of fields in mapping schemas as 
`"required": True` and `"required": False` 
instead of 
`"required": True` and `"optional": True` (or omitting the requirement key)

This also respects requirement of base schema (`required` argument of `vol.Schema`).

closes #156 

<hr>

In a voluptuous Schema a nested dict would inherit outer requirement. For example
```py
vol.Schema(
    {
        "outer": {
            "inner": int,
        }
    },
    required=True,
)
```
Here both, `outer` and `inner` would be required.
This PR does not account for this, as those nested mapping schemas are not supported by `convert()`.

<hr>

For backward compatibility, subtypes of `vol.Optional` (and `vol.Required` although there are none in voluptuous) still add their lower-case class name - like `optional: true`.