### PR TITLE
Remove deprecated `optional` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ _(dictionaries become lists to guarantee order of properties)_
     "type": "string",
     "default": "not specified",
     "required": false,
-    "optional": true,  // This is deprecated. Please use "required" key instead.
   }
 ]
 ```

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -97,7 +97,6 @@ def test_dict(base_required: bool) -> None:
             "type": "string",
             "default": "not specified",
             "required": False,
-            "optional": True,
         },
     ] == convert(
         vol.Schema(

--- a/voluptuous_serialize/__init__.py
+++ b/voluptuous_serialize/__init__.py
@@ -67,9 +67,6 @@ def convert(
             if isinstance(key, (vol.Required, vol.Optional)):
                 pval["required"] = isinstance(key, vol.Required)
 
-                # for backward compatibility
-                pval[key.__class__.__name__.lower()] = True
-
                 if not isinstance(key.default, vol.Undefined):
                     pval["default"] = key.default()
             else:


### PR DESCRIPTION
follow-up for https://github.com/home-assistant-libs/voluptuous-serialize/pull/159#discussion_r2231649791
for after the release following 2.6.0